### PR TITLE
test chat abierto y anonimo

### DIFF
--- a/packages/runox-angular/cypress/integration/spec.ts
+++ b/packages/runox-angular/cypress/integration/spec.ts
@@ -15,9 +15,16 @@ context('visitar home y revisar si tiene: ', () => {
 
   it('el chat esta abierto', () => {
     cy.visit('/');
-    cy.get('input#rnx-input-write-message').type('cypress test chat');
+    cy.get('input#rnx-input-write-message');
     cy.get('button#rnx-button-send-message');
+  });
+
+  it('el chat esta funcionando como anónimo', () => {
+    cy.visit('/');
+    cy.get('input#rnx-input-write-message').type('cypress test chat');
+    cy.get('button#rnx-button-send-message')
+      .click();
     cy.wait(3000);
     cy.contains('cypress test chat');
-  })
+  });
 });

--- a/packages/runox-angular/src/app/chat/chat-room/chat-room.component.html
+++ b/packages/runox-angular/src/app/chat/chat-room/chat-room.component.html
@@ -12,7 +12,7 @@
         </rnx-chat-burble>
       </div>
     </div>
-    <div id="chat-actions" *ngIf="player">
+    <div id="chat-actions">
         <input id="rnx-input-write-message" placeholder="Escribe tu mensaje" type="text" [(ngModel)]="newMessageText" (keypress)="onKeyPress($event)" />
         <button id="rnx-button-send-message" (click)="sendMessage()">Enviar</button>
     </div>

--- a/packages/runox-angular/src/app/chat/chat-room/chat-room.component.ts
+++ b/packages/runox-angular/src/app/chat/chat-room/chat-room.component.ts
@@ -16,6 +16,7 @@ import { ChatMessage } from "../models/chat-message";
 import { tap } from "rxjs/operators";
 
 const ENTER_CODE = 13;
+const ANONYMOUS_USERNAME = 'Anonimo';
 const PUBLIC_ROOM = "runox";
 @Component({
   selector: "rnx-chat-room",
@@ -62,9 +63,10 @@ export class ChatRoomComponent implements OnInit, OnDestroy {
   }
 
   sendMessage() {
-    if (this._roomName && this.player.name && this.newMessageText) {
+    if (this._roomName && this.newMessageText) {
+      const username = this.player ? this.player.name : ANONYMOUS_USERNAME;
       this.service
-        .createMessage(this._roomName, this.player.name, this.newMessageText)
+        .createMessage(this._roomName, username, this.newMessageText)
         .then(() => {
           this.newMessageText = "";
         })


### PR DESCRIPTION
el chat público (roomName = runox) permite escribir de forma anónimo

Hice un test para chequear que esté abierto 
**¡Qué bien!**
<img src="https://user-images.githubusercontent.com/20727215/90535079-e0995580-e150-11ea-9e8f-f85fd821920d.png" width="100" height="100">

 otro para verificar que se envíe el mensaje (spoiler, no me funcionó 😢 )
**¡Qué mal!**
<img src="https://user-images.githubusercontent.com/20727215/90535183-00c91480-e151-11ea-9652-9a465571fae3.png" width="100" height="100">

Pero la funcionalidad de chatear como anónimo está hecha
**¡Qué bien!**
<img src="https://user-images.githubusercontent.com/20727215/90535079-e0995580-e150-11ea-9e8f-f85fd821920d.png" width="100" height="100">

pero el PR tiene bensoato de potasio
**¿Ya puedo irme?**

<img src="https://user-images.githubusercontent.com/20727215/90535371-340ba380-e151-11ea-9b3e-cff95f1a161c.png" width="100" height="100">
